### PR TITLE
CYTHINF-75 Remove Pipeline Started Event Publishing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "editor.formatOnSave": true,
+  "editor.formatOnPaste": true,
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": true,
+    "source.fixAll": true
+  }
+}

--- a/cicd.template.yml
+++ b/cicd.template.yml
@@ -28,7 +28,7 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
-          - Effect: Allow 
+          - Effect: Allow
             Action: s3:*Object
             Resource:
               - !Sub arn:aws:s3:::${ArtifactStore}
@@ -47,16 +47,16 @@ Resources:
       EncryptionKey: !ImportValue cfn-utilities:ArtifactKeyArn
       Environment:
         Image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
-        ComputeType: BUILD_GENERAL1_SMALL 
+        ComputeType: BUILD_GENERAL1_SMALL
         EnvironmentVariables:
           - Name: ARTIFACT_STORE
             Value: !Ref ArtifactStore
         Type: LINUX_CONTAINER
       Artifacts:
         Type: CODEPIPELINE
-      Source: 
+      Source:
         Type: CODEPIPELINE
-  
+
   Webhook:
     Type: AWS::CodePipeline::Webhook
     Properties:
@@ -74,11 +74,11 @@ Resources:
   Pipeline:
     Type: AWS::CodePipeline::Pipeline
     Properties:
-      Name: !Sub ${AWS::StackName}-pipeline 
+      Name: !Sub ${AWS::StackName}-pipeline
       ArtifactStore:
         Type: S3
         Location: !Ref ArtifactStore
-        EncryptionKey: 
+        EncryptionKey:
           Id: !ImportValue cfn-utilities:ArtifactKeyArn
           Type: KMS
       RoleArn: !ImportValue cfn-utilities:MasterRoleArn
@@ -114,6 +114,23 @@ Resources:
                 - Name: buildResults
               Configuration:
                 ProjectName: !Ref BuildProject
+        - Name: Shared
+          Actions:
+            - Name: Deploy
+              RunOrder: 1
+              ActionTypeId:
+                Category: Deploy
+                Provider: CloudFormation
+                Owner: AWS
+                Version: 1
+              InputArtifacts:
+                - Name: buildResults
+              Configuration:
+                StackName: cfn-monitoring
+                ActionMode: CREATE_UPDATE
+                TemplatePath: buildResults::master.template.yml
+                RoleArn: !ImportValue cfn-utilities:MasterRoleArn
+                Capabilities: CAPABILITY_IAM
         - Name: Dev
           Actions:
             - Name: Deploy
@@ -150,20 +167,3 @@ Resources:
                 TemplatePath: buildResults::agent.template.yml.packaged
                 RoleArn: !ImportValue cfn-metadata:ProdAgentRoleArn
                 Capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
-        - Name: Shared
-          Actions:
-            - Name: Deploy
-              RunOrder: 1
-              ActionTypeId:
-                Category: Deploy
-                Provider: CloudFormation
-                Owner: AWS
-                Version: 1
-              InputArtifacts:
-                - Name: buildResults
-              Configuration:
-                StackName: cfn-monitoring
-                ActionMode: CREATE_UPDATE
-                TemplatePath: buildResults::master.template.yml
-                RoleArn: !ImportValue cfn-utilities:MasterRoleArn
-                Capabilities: CAPABILITY_IAM

--- a/deploy/master.template.yml
+++ b/deploy/master.template.yml
@@ -4,21 +4,3 @@ Resources:
     Properties:
       AWSServiceName: cloudwatch-crossaccount.amazonaws.com
       Description: Allows CloudWatch to assume CloudWatch-CrossAccountSharing roles in remote accounts on behalf of the current account in order to display data cross-account, cross region
-
-  PipelineStartedEvent:
-    Type: AWS::Events::Rule
-    Properties:
-      EventPattern:
-        source: ["aws.codepipeline"]
-        detail-type: ["CodePipeline Pipeline Execution State Change"]
-        detail:
-          state: ["STARTED"]
-      Targets:
-        - Id: Dev
-          Arn: !Sub 
-            - arn:aws:events:${AWS::Region}:${DevAccountId}:event-bus/default
-            - DevAccountId: !ImportValue cfn-metadata:DevAccountId
-        - Id: Prod
-          Arn: !Sub 
-            - arn:aws:events:${AWS::Region}:${ProdAccountId}:event-bus/default
-            - ProdAccountId: !ImportValue cfn-metadata:ProdAccountId

--- a/src/ServiceStopper/Handler.cs
+++ b/src/ServiceStopper/Handler.cs
@@ -1,19 +1,18 @@
 using System;
-using System.Linq;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+
 using Amazon.Lambda.Core;
-using Amazon.ResourceGroups;
-using Amazon.ResourceGroups.Model;
+
 using Cythral.CloudFormation.Monitoring.ServiceStopper.ServiceUtils;
 
-[assembly:LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
 
 namespace Cythral.CloudFormation.Monitoring.ServiceStopper
 {
     public class Handler
     {
-        private static ServiceListerFactory serviceListerFactory = new ServiceListerFactory();   
+        private static ServiceListerFactory serviceListerFactory = new ServiceListerFactory();
         private static ServiceScaler serviceScaler = new ServiceScaler();
 
         public static async Task Handle(Request request, ILambdaContext? context = null)
@@ -27,7 +26,8 @@ namespace Cythral.CloudFormation.Monitoring.ServiceStopper
                 var updatedAt = service.Deployments[0].UpdatedAt;
                 var diff = DateTime.Now - updatedAt;
 
-                if(diff.Hours == 0) {
+                if (diff.Hours == 0)
+                {
                     continue;
                 }
 

--- a/src/ServiceStopper/ServiceUtils/ServiceLister.cs
+++ b/src/ServiceStopper/ServiceUtils/ServiceLister.cs
@@ -1,11 +1,13 @@
 using System;
-using System.Threading.Tasks;
-using System.Linq;
 using System.Collections.Generic;
-using Amazon.ResourceGroups;
-using Amazon.ResourceGroups.Model;
+using System.Linq;
+using System.Threading.Tasks;
+
 using Amazon.ECS;
 using Amazon.ECS.Model;
+using Amazon.ResourceGroups;
+using Amazon.ResourceGroups.Model;
+
 using Cythral.CloudFormation.Monitoring.ServiceStopper.Aws;
 
 using Task = System.Threading.Tasks.Task;
@@ -47,18 +49,20 @@ namespace Cythral.CloudFormation.Monitoring.ServiceStopper.ServiceUtils
 
             return listGroupResourcesResponse.ResourceIdentifiers.Select(identifier => identifier.ResourceArn).ToList();
         }
-        
+
         private Dictionary<string, List<string>> GetClusterToServiceArnsDict(List<string> clusterArns)
         {
             var result = new Dictionary<string, List<string>>();
             var tasks = new List<Task>();
-            
+
             foreach (var clusterArn in clusterArns)
             {
-                var task = Task.Run(async delegate {
+                var task = Task.Run(async delegate
+                {
                     var serviceArns = await GetServiceArnsForCluster(clusterArn);
-                    
-                    lock (result) {
+
+                    lock (result)
+                    {
                         result.Add(clusterArn, serviceArns);
                     }
                 });
@@ -85,13 +89,15 @@ namespace Cythral.CloudFormation.Monitoring.ServiceStopper.ServiceUtils
         {
             var results = new List<Service>();
             var tasks = new List<Task>();
-            
-            foreach(var entry in clusterToServiceArns)
+
+            foreach (var entry in clusterToServiceArns)
             {
-                var task = Task.Run(async delegate {
+                var task = Task.Run(async delegate
+                {
                     var services = await GetServicesForCluster(entry.Key, entry.Value);
 
-                    lock (results) {
+                    lock (results)
+                    {
                         results.AddRange(services);
                     }
                 });

--- a/tests/Core/ReflectionUtils.cs
+++ b/tests/Core/ReflectionUtils.cs
@@ -5,25 +5,25 @@ namespace Cythral.CloudFormation.Monitoring.Tests
 {
     public class ReflectionUtils
     {
-        public static void SetPrivateProperty<T, U>(T target, string name, U value) 
+        public static void SetPrivateProperty<T, U>(T target, string name, U value)
         {
             var prop = target?.GetType()?.GetProperty(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
             prop?.SetValue(target, value);
         }
 
-        public static void SetPrivateField<T, U>(T target, string name, U value) 
+        public static void SetPrivateField<T, U>(T target, string name, U value)
         {
             var prop = target?.GetType()?.GetField(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
             prop?.SetValue(target, value);
         }
 
-        public static void SetPrivateStaticField<T>(Type target, string name, T value) 
+        public static void SetPrivateStaticField<T>(Type target, string name, T value)
         {
             var prop = target?.GetField(name, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy);
             prop?.SetValue(target, value);
         }
 
-        public static void SetReadonlyField<T, U>(T target, string name, U value) 
+        public static void SetReadonlyField<T, U>(T target, string name, U value)
         {
             var field = target?.GetType()?.GetField(name, BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy);
             field?.SetValue(target, value);

--- a/tests/ServiceStopperTests/HandlerTests.cs
+++ b/tests/ServiceStopperTests/HandlerTests.cs
@@ -1,10 +1,14 @@
-using System.Collections.Generic;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
-using NSubstitute;
-using FluentAssertions;
-using NUnit.Framework;
+
 using Amazon.ECS.Model;
+
+using FluentAssertions;
+
+using NSubstitute;
+
+using NUnit.Framework;
 
 using Task = System.Threading.Tasks.Task;
 
@@ -19,7 +23,8 @@ namespace Cythral.CloudFormation.Monitoring.Tests.ServiceStopper
         ServiceScaler serviceScaler = null!;
         ServiceLister serviceLister = null!;
 
-        static Service StoppableService = new Service {
+        static Service StoppableService = new Service
+        {
             Deployments = new List<Deployment> {
                 new Deployment {
                     UpdatedAt = DateTime.Now.AddHours(-2)
@@ -27,7 +32,8 @@ namespace Cythral.CloudFormation.Monitoring.Tests.ServiceStopper
             }
         };
 
-        static Service UnstoppableService = new Service {
+        static Service UnstoppableService = new Service
+        {
             Deployments = new List<Deployment> {
                 new Deployment {
                     UpdatedAt = DateTime.Now.AddMinutes(-30)
@@ -42,7 +48,7 @@ namespace Cythral.CloudFormation.Monitoring.Tests.ServiceStopper
                 MonitoredClustersGroupName = monitoredClusterGroupName
             };
         }
-        
+
         [SetUp]
         public void SetupServiceLister()
         {

--- a/tests/ServiceStopperTests/ServiceUtils/ServiceScalerTests.cs
+++ b/tests/ServiceStopperTests/ServiceUtils/ServiceScalerTests.cs
@@ -1,12 +1,15 @@
 using System;
 using System.Threading.Tasks;
-using NSubstitute;
-using FluentAssertions;
-using NUnit.Framework;
+
 using Amazon.ECS;
 using Amazon.ECS.Model;
+
 using Cythral.CloudFormation.Monitoring.ServiceStopper.Aws;
 using Cythral.CloudFormation.Monitoring.ServiceStopper.ServiceUtils;
+
+using NSubstitute;
+
+using NUnit.Framework;
 
 using Task = System.Threading.Tasks.Task;
 
@@ -63,8 +66,8 @@ namespace Cythral.CloudFormation.Monitoring.Tests.ServiceStopper.ServiceUtils
 
             await serviceScaler.ScaleDown(service);
 
-            await ecsClient.Received().UpdateServiceAsync(Arg.Is<UpdateServiceRequest>(arg => 
-                arg.Cluster == clusterArn && 
+            await ecsClient.Received().UpdateServiceAsync(Arg.Is<UpdateServiceRequest>(arg =>
+                arg.Cluster == clusterArn &&
                 arg.Service == serviceArn &&
                 arg.DesiredCount == 0
             ));


### PR DESCRIPTION
This removes the part of the master template that enabled publishing pipeline started events to dev and prod, since that is no longer needed.  I also went through and formatted all cs files and organized imports. 