### PR TITLE
CYTHINF-69 Globally Ignore Cfn-lint Checks

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -1,0 +1,3 @@
+ignore_checks:
+  - E3001
+  - E3006

--- a/deploy/agent.template.yml
+++ b/deploy/agent.template.yml
@@ -4,12 +4,6 @@ Resources:
     Name: AWS::Include
     Properties:
       Location: ./cloudtrail.template.yml
-    Metadata:
-      cfn-lint:
-        config:
-          ignore_checks:
-            - E3001
-            - E3006
 
   SharingRole:
     Type: AWS::IAM::Role

--- a/deploy/master.template.yml
+++ b/deploy/master.template.yml
@@ -9,9 +9,3 @@ Resources:
     Name: AWS::Include
     Properties:
       Location: ./cloudtrail.template.yml
-    Metadata:
-      cfn-lint:
-        config:
-          ignore_checks:
-            - E3001
-            - E3006


### PR DESCRIPTION
Globally ignore cfn-lint checks - the inline metadata one is messing up the cloudformation package command.