### PR TITLE
CYTHINF-69 Remove ./ Prefix from Location

### DIFF
--- a/deploy/agent.template.yml
+++ b/deploy/agent.template.yml
@@ -3,7 +3,7 @@ Resources:
   Fn::Transform:
     Name: AWS::Include
     Properties:
-      Location: ./cloudtrail.template.yml
+      Location: cloudtrail.template.yml
 
   SharingRole:
     Type: AWS::IAM::Role

--- a/deploy/master.template.yml
+++ b/deploy/master.template.yml
@@ -8,4 +8,4 @@ Resources:
   Fn::Transform:
     Name: AWS::Include
     Properties:
-      Location: ./cloudtrail.template.yml
+      Location: cloudtrail.template.yml


### PR DESCRIPTION
Removes the ./ prefix from the Location parameter of the AWS::Include transform